### PR TITLE
modified cloneObj to handle Streams

### DIFF
--- a/elvis-request.js
+++ b/elvis-request.js
@@ -4,11 +4,11 @@ var request = Promise.promisify(require('request').defaults({ jar: true , pool: 
 Promise.promisifyAll(request, { multiArgs: true })
 
 module.exports = (config) => {
-  
+
   var csrfToken;
 
   function cloneObj(obj) {
-    return JSON.parse(JSON.stringify(obj));
+    return {...obj};
   }
 
   function parseBody(result) {
@@ -47,7 +47,7 @@ module.exports = (config) => {
       }
       else {
         options.url = config.serverUrl + options.url;
-      } 
+      }
     }
 
     if (csrfToken) {


### PR DESCRIPTION
The cloneObj fails when making requests with Streams such as when trying to update an asset's Filedata.